### PR TITLE
adjust news title to be at the bottom of image not at the top

### DIFF
--- a/src/components/RssChannel.vue
+++ b/src/components/RssChannel.vue
@@ -91,14 +91,12 @@ export default {
         position: absolute;
         box-sizing: border-box;
         color: @white;
+        bottom: 10px;
         .news-title {
           color: @white;
           @media (min-device-width: 768px) and (max-device-width: 1024px) {
             font-size: small;
           }
-        }
-        .news-date {
-          top: 70px;
         }
       }
     }


### PR DESCRIPTION
the reason behind this pr: 
======================================
1- styling only (less changes)
2- change the title position to be at the bottom of the image not at the top
3- all changes happened at rss channel component